### PR TITLE
Remove player select from beer side

### DIFF
--- a/src/app/components/AlertComponent.tsx
+++ b/src/app/components/AlertComponent.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Alert, Snackbar } from "@mui/material";
 
 interface AlertComponentProps {
@@ -14,25 +14,86 @@ const AlertComponent: React.FC<AlertComponentProps> = ({
   open,
   setOpen,
 }) => {
+  const audioRef = useRef<{ [key: string]: HTMLAudioElement | null }>({});
+
+  // Load audio files once
+  useEffect(() => {
+    audioRef.current["success"] = new Audio("/sounds/confirmation.mp3");
+    audioRef.current["error"] = new Audio("/sounds/error.mp3");
+
+    // Set volume and preload
+    Object.values(audioRef.current).forEach((audio) => {
+      if (audio) {
+        audio.volume = 0.5;
+        audio.preload = "auto";
+      }
+    });
+
+    const enableAudio = () => {
+      Object.values(audioRef.current).forEach((audio) => {
+        audio
+          ?.play()
+          .then(() => {
+            audio.pause();
+            audio.currentTime = 0;
+          })
+          .catch((_) => {});
+      });
+      document.removeEventListener("click", enableAudio);
+      document.removeEventListener("touchstart", enableAudio);
+    };
+
+    document.addEventListener("click", enableAudio);
+    document.addEventListener("touchstart", enableAudio);
+
+    return () => {
+      document.removeEventListener("click", enableAudio);
+      document.removeEventListener("touchstart", enableAudio);
+    };
+  }, []);
+
   useEffect(() => {
     if (open) {
       const playSound = () => {
-        let audio: HTMLAudioElement;
-        switch (severity) {
-          case "success":
-            audio = new Audio("/sounds/confirmation.mp3");
-            break;
-          case "error":
-          case "warning":
-            audio = new Audio("/sounds/error.mp3");
-            break;
-          default:
-            return;
+        try {
+          let audio: HTMLAudioElement;
+          switch (severity) {
+            case "success":
+              audio = audioRef.current["success"]!;
+              break;
+            case "error":
+            case "warning":
+              audio = audioRef.current["error"]!;
+              break;
+            default:
+              return;
+          }
+          audio.play();
+        } catch (error) {
+          console.error("Sound error: ", error);
         }
-        audio.play();
       };
 
-      // playSound();
+      const playVibration = () => {
+        if ("vibrate" in navigator) {
+          switch (severity) {
+            case "success":
+              navigator.vibrate?.([100, 50, 100]);
+              break;
+            case "error":
+              navigator.vibrate?.([200, 100, 200, 100, 200]);
+              break;
+            case "warning":
+              navigator.vibrate?.([150, 75, 150]);
+              break;
+            default:
+              break;
+          }
+        }
+      };
+
+      playSound();
+      playVibration();
 
       const timer = setTimeout(() => {
         setOpen(false);

--- a/src/app/judge-it/BeerJudge.tsx
+++ b/src/app/judge-it/BeerJudge.tsx
@@ -2,7 +2,12 @@ import React, { useCallback } from "react";
 import { supabase } from "@/SupabaseClient";
 import AlertComponent from "../components/AlertComponent";
 import { Button, Stack } from "@mui/material";
-import { getPlayerName, getCurrentHeat, getPlayer, getPlayerIdGivenTeamAndTimeLogs } from "@/utils/getUtils";
+import {
+  getPlayerName,
+  getCurrentHeat,
+  getPlayer,
+  getPlayerIdGivenTeamAndTimeLogs,
+} from "@/utils/getUtils";
 import {
   TIME_LOGS_TABLE,
   TIME_TYPE_SAIL,
@@ -26,9 +31,14 @@ const BeerJudge: React.FC<BeerJudgeProps> = ({
   timeLogs = [],
   alert,
 }) => {
-
-  const latestPlayer = getPlayerIdGivenTeamAndTimeLogs(selectedTeam || 0, timeLogs);
-  const playerName = getPlayerName(latestPlayer || 0, players);
+  const latestPlayer =
+    selectedTeam !== null
+      ? getPlayerIdGivenTeamAndTimeLogs(selectedTeam, timeLogs)
+      : null;
+  const playerName =
+    latestPlayer !== null
+      ? getPlayerName(latestPlayer, players)
+      : "player null";
   /**
    * Create buttons for each time type
    *

--- a/src/app/judge-it/page.tsx
+++ b/src/app/judge-it/page.tsx
@@ -95,24 +95,26 @@ function Judge(): React.ReactElement {
           />
         </Box>
 
-        <Box>
-          {/**
-           * Show player selection as a group of radio buttons
-           * Disable the radio group if there are no players
-           */}
-          <PlayerSelect
-            teams={teams}
-            selectedTeamId={selectedTeamId}
-            selectedPlayer={selectedPlayer}
-            setSelectedPlayer={setSelectedPlayer}
-            players={players}
-            teamPlayers={teamPlayers}
-            setTeamPlayers={setTeamPlayers}
-            selectPlayerString={selectPlayerString}
-            setSelectPlayerString={setSelectPlayerString}
-            alert={alert}
-          />
-        </Box>
+        {judgeType !== BEER_JUDGE && (
+          <Box>
+            {/**
+             * Show player selection as a group of radio buttons
+             * Disable the radio group if there are no players
+             */}
+            <PlayerSelect
+              teams={teams}
+              selectedTeamId={selectedTeamId}
+              selectedPlayer={selectedPlayer}
+              setSelectedPlayer={setSelectedPlayer}
+              players={players}
+              teamPlayers={teamPlayers}
+              setTeamPlayers={setTeamPlayers}
+              selectPlayerString={selectPlayerString}
+              setSelectPlayerString={setSelectPlayerString}
+              alert={alert}
+            />
+          </Box>
+        )}
         {/**
          * Display the specific judge extra functionality
          *
@@ -149,8 +151,8 @@ function Judge(): React.ReactElement {
         {judgeType === BEER_JUDGE && (
           <BeerJudge
             players={players}
+            timeLogs={timeLogs}
             selectedTeam={selectedTeamId ? Number(selectedTeamId) : null}
-            selectedPlayer={selectedPlayer ? Number(selectedPlayer) : null}
             timeTypes={timeTypes}
             alert={alert}
           />

--- a/src/utils/getUtils.ts
+++ b/src/utils/getUtils.ts
@@ -8,7 +8,7 @@ import {
   calculateTimes,
   removeDuplicateTimeEntries,
 } from "./visualizationUtils";
-import { sortTimeLogsByHeat, splitTimeLogsPerHeat } from "./sortFilterUtils";
+import { filterTimeLogsByTeamId, sortTimeLogsByHeat, splitTimeLogsPerHeat } from "./sortFilterUtils";
 import { supabase } from "@/SupabaseClient";
 import type { Player, Heat, Team, TimeType, TimeLog } from "@/types";
 import { t } from "node_modules/framer-motion/dist/types.d-CtuPurYT";
@@ -355,9 +355,8 @@ export const getPlayerIdGivenTeamAndTimeLogs = (
   teamId: number,
   timeLogs: TimeLog[]
 ): number | null => {
-  const recentLogs = sortTimeLogsByHeat(timeLogs).filter(
-    (log) => log.team_id === teamId
-  );
+  const teamLogs = filterTimeLogsByTeamId(timeLogs, teamId);
+  const recentLogs = sortTimeLogsByHeat(teamLogs);
   if (recentLogs.length === 0) return null;
   const latestLog = recentLogs[recentLogs.length - 1];
   const playerId = latestLog.player_id;

--- a/src/utils/getUtils.ts
+++ b/src/utils/getUtils.ts
@@ -8,7 +8,7 @@ import {
   calculateTimes,
   removeDuplicateTimeEntries,
 } from "./visualizationUtils";
-import { splitTimeLogsPerHeat } from "./sortFilterUtils";
+import { sortTimeLogsByHeat, splitTimeLogsPerHeat } from "./sortFilterUtils";
 import { supabase } from "@/SupabaseClient";
 import type { Player, Heat, Team, TimeType, TimeLog } from "@/types";
 import { t } from "node_modules/framer-motion/dist/types.d-CtuPurYT";
@@ -349,4 +349,17 @@ export const getPlayerImageWithFallback = (
   // Otherwise, get the team's image as fallback
   const team = getPlayerTeam(playerId, teams);
   return team?.image_url || "";
+};
+
+export const getPlayerIdGivenTeamAndTimeLogs = (
+  teamId: number,
+  timeLogs: TimeLog[]
+): number | null => {
+  const recentLogs = sortTimeLogsByHeat(timeLogs).filter(
+    (log) => log.team_id === teamId
+  );
+  if (recentLogs.length === 0) return null;
+  const latestLog = recentLogs[recentLogs.length - 1];
+  const playerId = latestLog.player_id;
+  return playerId ? playerId : null;
 };

--- a/src/utils/getUtils.ts
+++ b/src/utils/getUtils.ts
@@ -8,7 +8,11 @@ import {
   calculateTimes,
   removeDuplicateTimeEntries,
 } from "./visualizationUtils";
-import { filterTimeLogsByTeamId, sortTimeLogsByHeat, splitTimeLogsPerHeat } from "./sortFilterUtils";
+import {
+  filterTimeLogsByTeamId,
+  sortTimeLogsByHeat,
+  splitTimeLogsPerHeat,
+} from "./sortFilterUtils";
 import { supabase } from "@/SupabaseClient";
 import type { Player, Heat, Team, TimeType, TimeLog } from "@/types";
 import { t } from "node_modules/framer-motion/dist/types.d-CtuPurYT";

--- a/src/utils/sortFilterUtils.ts
+++ b/src/utils/sortFilterUtils.ts
@@ -28,7 +28,7 @@ export const filterTimeLogsByTeamId = (
 };
 
 /**
- * Sorts time logs by heat ID.
+ * Sorts time logs by heat ID in ascending order.
  * @param {Array} timeLogs - The list of time logs.
  * @returns {Array} The sorted time logs by heat ID.
  */


### PR DESCRIPTION
**Related Issue(s):**

<!-- Link to the issue(s) this PR addresses. E.g., "Closes #123". If new, please create an issue first. -->
- Closes #94 

**Description of Changes:**

<!-- Briefly describe what you've changed and why. -->
- Removes player select from beer side and instead calculate which one to use
- Also taps into audio and vibration

**Type of Change:**

<!-- Check one: -->
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor/Style/Performance
- [ ] Other:

**Key Checklist:**

<!-- Please ensure these are done. -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/itu-campuscup/judge-it/blob/main/CONTRIBUTING.md).
- [ ] My code follows the project's style guidelines (linting/formatting passed).
- [ ] I have performed a self-review of my code.

**Screenshots/Screen Recordings (if UI changes):**

<!-- Add here if applicable. -->

**Notes for Reviewer (optional):**

<!-- Anything specific you want the reviewer to look at? -->

---
<!-- For your first PR, remember to add yourself to all-contributors! -->
<!-- This is done by making a comment to this PR with the below, and putting in your GitHub handle in `<username>` -->
<!-- @all-contributors please add @<username> for code -->
