### PR TITLE
🛡️ Sentinel: [HIGH] Fix Broken Access Control in data queries

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The administrative endpoints (`listUsers`, `approveUser`, `disapproveUser`) in `convex/admin.ts` were accessible to any authenticated user. This allowed any registered user to view other users' emails and approve their own or others' accounts.
 **Learning:** Initial implementation relied on UI-level checks and comments (`// In production, verify the current user is an admin`) without enforcing backend authorization. This is a classic "Broken Access Control" pattern.
 **Prevention:** Always enforce authorization at the database/API layer using dedicated helpers (`requireAdminUser`). Never rely solely on UI-level hiding of features.
+
+## 2025-05-23 - Missing User Authorization on Data Queries
+**Vulnerability:** All 16 application data queries in `convex/queries.ts` lacked authorization checks. Any authenticated user, including those pending admin approval, could fetch sensitive competition data.
+**Learning:** UI-level route protection (e.g., `RequireApproval` component) only secures the visual interface. APIs and database queries must independently verify user permissions to prevent direct data extraction.
+**Prevention:** Implement mandatory authorization helpers (e.g., `requireApprovedUser`) at the start of every query and mutation handler that deals with non-public data.


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Broken Access Control in data queries

### 🚨 Severity: HIGH

### 💡 Vulnerability
All application data queries in `convex/queries.ts` were missing authorization checks. While the frontend uses a `RequireApproval` wrapper to protect routes, the underlying Convex queries did not enforce this on the server side.

### 🎯 Impact
Any authenticated user, even if their account was still "Pending Approval", could directly call these queries to retrieve all players, teams, heats, and time logs. This constituted a Broken Access Control vulnerability where sensitive competition data could be leaked to unauthorized users.

### 🔧 Fix
- Imported the `requireApprovedUser` helper in `convex/queries.ts`.
- Added `await requireApprovedUser(ctx)` to the beginning of every query handler.
- This ensures that Convex will reject the request if the user is not explicitly approved by an administrator.
- Note: `getCurrentUserStatus` in `convex/admin.ts` was intentionally left without this check as it is used by the frontend to determine if the user *is* approved.

### ✅ Verification
- Ran `bun lint` to ensure code style consistency.
- Ran `bun run build` to verify the project builds correctly.
- Ran `bun run test` (focusing on `auth.spec.ts` and `homepage.spec.ts`) to ensure existing functionality remains intact.
- Verified file content manually to ensure all 16 handlers are protected.

Note: The `convex/` directory is a submodule. Changes have been committed within the submodule, and the submodule pointer has been updated in this repository.

---
*PR created automatically by Jules for task [579935581247183651](https://jules.google.com/task/579935581247183651) started by @lucasfth*