### PR TITLE
🛡️ Sentinel: Guard Bun.secrets and Prioritize Environment Variables in Config Loading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The administrative endpoints (`listUsers`, `approveUser`, `disapproveUser`) in `convex/admin.ts` were accessible to any authenticated user. This allowed any registered user to view other users' emails and approve their own or others' accounts.
 **Learning:** Initial implementation relied on UI-level checks and comments (`// In production, verify the current user is an admin`) without enforcing backend authorization. This is a classic "Broken Access Control" pattern.
 **Prevention:** Always enforce authorization at the database/API layer using dedicated helpers (`requireAdminUser`). Never rely solely on UI-level hiding of features.
+
+## 2026-03-02 - Unprotected OS Keychain Access & Missing Fallbacks
+**Vulnerability:** Access to `Bun.secrets` was unguarded and prioritized over standard environment variables. This caused fatal crashes and hangs in environments where OS keychain APIs are unavailable, disabled, or non-interactive (e.g., Docker, Playwright, headless servers).
+**Learning:** Hard-dependencies on OS-level native integration modules without fallbacks or presence-checking introduces system-level Denial of Service (DoS) and execution fragility.
+**Prevention:** Always check if native system integration modules (like `secrets`) are defined (`typeof secrets !== "undefined"`) before calling their methods. Prioritize standard, secure environment variables (`Bun.env`) over keychain storage to allow headless/non-interactive environments to bypass keychain interaction entirely.

--- a/cli.ts
+++ b/cli.ts
@@ -103,6 +103,13 @@ async function viewSecrets() {
   const envLabel = env ? ` [${env}]` : "";
   console.log(`[INFO]\t Stored credentials${envLabel}:`);
 
+  if (typeof secrets === "undefined" || !secrets) {
+    console.error(
+      "[ERROR]\t Bun secrets are not available in this environment.",
+    );
+    return;
+  }
+
   for (const key of KEYS) {
     const storageKey = key + envSuffix;
     try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,28 +37,35 @@ const getOrPrompt = async (
 ): Promise<string | null> => {
   const storageKey = envKey + envSuffix;
 
+  // Priority: check environment variable first to avoid keychain prompts/failures
+  const fromEnv = Bun.env[envKey];
+  if (fromEnv) {
+    console.log(`[INFO]\t Loaded ${envKey} from environment`);
+    return fromEnv;
+  }
+
   // In CI we must not access the OS keychain — read only from environment
   if (isCI()) {
-    const fromEnv = Bun.env[envKey];
-    if (fromEnv) {
-      console.log(`[INFO]\t Loaded ${envKey} from environment (CI)`);
-      return fromEnv;
-    }
     return null;
   }
 
-  // Local/dev flow: try Bun.secrets for keychain storage first
-  try {
-    const stored = await secrets.get({
-      service: SECRET_SERVICE,
-      name: storageKey,
-    });
-    if (stored) {
-      console.log(`[INFO]\t Loaded ${storageKey} from keychain`);
-      return stored;
+  // Local/dev flow: try Bun.secrets for keychain storage first if available
+  if (typeof secrets !== "undefined" && secrets) {
+    try {
+      const stored = await secrets.get({
+        service: SECRET_SERVICE,
+        name: storageKey,
+      });
+      if (stored) {
+        console.log(`[INFO]\t Loaded ${storageKey} from keychain`);
+        return stored;
+      }
+    } catch (err) {
+      console.error(
+        `[ERROR]\t Error accessing secrets for ${storageKey}:`,
+        err,
+      );
     }
-  } catch (err) {
-    console.error(`[ERROR]\t Error accessing secrets for ${storageKey}:`, err);
   }
 
   // Interactive prompt (only on TTY)
@@ -68,13 +75,15 @@ const getOrPrompt = async (
       const entered = prompt(`Enter ${displayName}:`);
       if (entered) {
         try {
-          // Save to Bun.secrets for future local runs
-          await secrets.set({
-            service: SECRET_SERVICE,
-            name: storageKey,
-            value: entered,
-          });
-          console.log(`[INFO]\t Saved ${storageKey} to keychain`);
+          // Save to Bun.secrets for future local runs if available
+          if (typeof secrets !== "undefined" && secrets) {
+            await secrets.set({
+              service: SECRET_SERVICE,
+              name: storageKey,
+              value: entered,
+            });
+            console.log(`[INFO]\t Saved ${storageKey} to keychain`);
+          }
           return entered;
         } catch (saveErr) {
           console.error(
@@ -130,6 +139,10 @@ export const readAppConfig = async (env?: string) => {
 export const clearStoredSecrets = async (env?: string): Promise<void> => {
   const envSuffix = env ? `_${env.toUpperCase()}` : "";
   const keysToDelete = ["NEXT_PUBLIC_CONVEX_URL"];
+  if (typeof secrets === "undefined" || !secrets) {
+    console.warn("[WARN]\t Bun secrets are not available in this environment.");
+    return;
+  }
   try {
     for (const key of keysToDelete) {
       await secrets.delete({


### PR DESCRIPTION
### 🛡️ Sentinel: Guard Bun.secrets and Prioritize Environment Variables in Config Loading

#### 💡 Vulnerability / Bug:
Access to `Bun.secrets` was unguarded and prioritized over standard environment variables. This caused fatal crashes (`TypeError: undefined is not an object`) and hangs in environments where OS keychain APIs are unavailable, disabled, or non-interactive (e.g., Docker, Playwright, headless servers).

#### 🔧 Fix:
- Prioritized standard environment variables (`Bun.env[envKey]`) over `secrets` keychain checks, allowing headless or non-interactive environments to load configuration smoothly without keychain interaction.
- Guarded all direct accesses to Bun's `secrets` module in both `src/config.ts` and `cli.ts` with `typeof secrets !== "undefined" && secrets` checks to prevent runtime errors when the native module is not supported.

#### ✅ Verification:
- All 51 E2E tests pass perfectly in CI/CD environment with `CI=true NEXT_PUBLIC_CONVEX_URL=https://happy-animal-123.convex.cloud bun run test`.
- Verified formatting and linting (`bun lint`).
- Updated the Sentinel Journal (`.jules/sentinel.md`) and recorded learnings in the agent's long-term memory.

---
*PR created automatically by Jules for task [9972310601537196532](https://jules.google.com/task/9972310601537196532) started by @lucasfth*