### PR TITLE
⚡ Bolt: Optimize date and year extraction logic

### DIFF
--- a/src/app/judge-it/SetHeat.tsx
+++ b/src/app/judge-it/SetHeat.tsx
@@ -21,7 +21,8 @@ const SetHeat: React.FC = () => {
   const thisYearsHeats = useMemo(
     () =>
       heats.filter(
-        (heat: Heat) => new Date(heat.date).getFullYear() === getCurYear(),
+        (heat: Heat) =>
+          parseInt(heat.date.substring(0, 4), 10) === getCurYear(),
       ),
     [heats],
   );

--- a/src/utils/getUtils.ts
+++ b/src/utils/getUtils.ts
@@ -63,13 +63,15 @@ export const getHeatNumber = (heatId: Id<"heats">, heats: Heat[]): string => {
 
 /**
  * Get the heat year given the heat ID.
+ * Performance Optimization: Extract the year from the date string 'YYYY-MM-DD'
+ * using substring(0, 4) instead of split('-')[0] to avoid creating temporary arrays.
  * @param {Id<"heats">} heatId - The heat ID.
  * @param {Array} heats - The list of heats.
  * @returns {string} The heat year.
  */
 export const getHeatYear = (heatId: Id<"heats">, heats: Heat[]): string => {
   const heat = heats.find((h: Heat) => h.id === heatId);
-  return heat ? heat.date.split("-")[0] : "";
+  return heat ? heat.date.substring(0, 4) : "";
 };
 
 /**

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -82,11 +82,13 @@ export const calcTimeDifference = (
 
 /**
  * Gives the unique years given an array of heats.
+ * Performance Optimization: Extract the year from the date string 'YYYY-MM-DD'
+ * using substring and parseInt, which is faster and avoids expensive Date object instantiation.
  * @param {Array} heats - The array of heats.
  * @returns {Array} The unique years - sorted by year in descending order.
  */
 export const getUniqueYearsGivenHeats = (heats: Heat[]): number[] => {
   return [
-    ...new Set(heats.map((heat) => new Date(heat.date).getFullYear())),
+    ...new Set(heats.map((heat) => parseInt(heat.date.substring(0, 4), 10))),
   ].sort((a, b) => b - a);
 };

--- a/src/utils/visualizationUtils.ts
+++ b/src/utils/visualizationUtils.ts
@@ -31,7 +31,9 @@ export const filterAndSortTimeLogs = (
 ): TimeLog[] => {
   const heatIdsInYear = new Set(
     heats
-      .filter((heat) => new Date(heat.date).getFullYear() === selectedYear)
+      .filter(
+        (heat) => parseInt(heat.date.substring(0, 4), 10) === selectedYear,
+      )
       .map((heat) => heat.id),
   );
 


### PR DESCRIPTION
💡 **What**: Optimized several date-parsing locations where the year of a heat is extracted.

🎯 **Why**: Instantiating a `new Date` object inside filter loops is expensive and creates unnecessary memory overhead. Similarly, using `.split('-')[0]` on simple ISO date strings ('YYYY-MM-DD') creates temporary arrays which can be avoided by utilizing `.substring(0, 4)`.

📊 **Impact**: Faster execution and reduced garbage collection overhead when sorting and filtering heats in stats or when configuring/judging heats.

🔬 **Measurement**: Verified using the existing E2E test suite (`bun run test`) which continues to pass perfectly. Checked through `bun lint` that there are no linter or type errors introduced.

---
*PR created automatically by Jules for task [17800528882932301198](https://jules.google.com/task/17800528882932301198) started by @lucasfth*