### PR TITLE
⚡ Bolt: Optimize generateRankableData with O(1) Map lookups

### DIFF
--- a/src/utils/visualizationUtils.ts
+++ b/src/utils/visualizationUtils.ts
@@ -7,8 +7,6 @@ import {
   milliToSecs,
 } from "./timeUtils";
 import {
-  getPlayerName,
-  getHeatNumber,
   getTeamName,
   getPlayerFunFact,
   getTeamImageUrl,
@@ -146,6 +144,8 @@ export const removeDuplicateTimeEntries = (
 
 /**
  * Generates the chart data for the top times.
+ * Performance Optimization: Pre-calculates Map lookups for players, teams, heats, and player-to-team
+ * relationships to achieve O(1) lookups per entry instead of O(P + T + H) nested array scans.
  * @param {Array} topTimes - The top times.
  * @param {Array} players - The list of players.
  * @param {Array} teams - The list of teams.
@@ -164,13 +164,41 @@ export const generateRankableData = (
   teamName: string;
   heatNumber: string;
 }> => {
-  return topTimes.map((time) => ({
-    time: time.duration ?? 0,
-    imageUrl: getPlayerImageWithFallback(time.playerId, players, teams),
-    playerName: getPlayerName(time.playerId, players),
-    teamName: time.teamId ? getTeamName(time.teamId, teams) : "",
-    heatNumber: getHeatNumber(time.heatId, heats),
-  }));
+  const playerMap = new Map(players.map((p) => [p.id, p]));
+  const teamMap = new Map(teams.map((t) => [t.id, t]));
+  const heatMap = new Map(heats.map((h) => [h.id, h]));
+
+  const playerTeamMap = new Map<Id<"players">, Team>();
+  for (const team of teams) {
+    if (team.player_1_id) playerTeamMap.set(team.player_1_id, team);
+    if (team.player_2_id) playerTeamMap.set(team.player_2_id, team);
+    if (team.player_3_id) playerTeamMap.set(team.player_3_id, team);
+    if (team.player_4_id) playerTeamMap.set(team.player_4_id, team);
+  }
+
+  return topTimes.map((time) => {
+    const player = playerMap.get(time.playerId);
+    const team = time.teamId ? teamMap.get(time.teamId) : undefined;
+    const heat = heatMap.get(time.heatId);
+
+    const playerName = player ? player.name : "";
+    const teamName = team ? team.name : "";
+    const heatNumber = heat ? heat.heat.toString() : "";
+
+    let imageUrl = player?.image_url || "";
+    if (!imageUrl) {
+      const playerTeam = playerTeamMap.get(time.playerId);
+      imageUrl = playerTeam?.image_url || "";
+    }
+
+    return {
+      time: time.duration ?? 0,
+      imageUrl,
+      playerName,
+      teamName,
+      heatNumber,
+    };
+  });
 };
 
 /**


### PR DESCRIPTION
### 💡 What
Optimized `generateRankableData` in `src/utils/visualizationUtils.ts` by pre-building lookup `Map` instances for `players`, `teams`, `heats`, and player-to-team relationships (`playerTeamMap`). Unused imports `getPlayerName` and `getHeatNumber` were removed.

### 🎯 Why
Previously, `generateRankableData` called `getPlayerImageWithFallback`, `getPlayerName`, `getTeamName`, and `getHeatNumber` inside a `.map()` over `topTimes`. Each helper scanned the respective array using `.find()`. For $N$ entries and entity arrays of size $P$, $T$, and $H$, this incurred an $O(N \times (P + T + H))$ complexity, causing redundant array scans on every render of ranking components (`BeerChugger` and `Sailing`).

### 📊 Impact
Reduces entity lookup time complexity from $O(N \times (P + T + H))$ to $O(N + P + T + H)$, guaranteeing $O(1)$ lookups per rankable time entry during chart data generation.

### 🔬 Measurement
Verified via `bun lint` and full Playwright test suite (`CI=true NEXT_PUBLIC_CONVEX_URL=https://happy-animal-123.convex.cloud bun run test`). All 51 active E2E tests pass cleanly.

---
*PR created automatically by Jules for task [1037867731817566925](https://jules.google.com/task/1037867731817566925) started by @lucasfth*